### PR TITLE
Fix a build error about the format %a

### DIFF
--- a/src/lookup_kas.c
+++ b/src/lookup_kas.c
@@ -101,7 +101,7 @@ static int lookup_kas_proc(__u64 pc, struct loc_result *location)
 		 *  - "%pK %c %s\n" (for kernel internal symbols), or
 		 *  - "%pK %c %s\t[%s]\n" (for module-provided symbols)
 		 */
-		fscanf(pf, "%llx %*s %as [ %*[^]] ]", &ppc, &name);
+		fscanf(pf, "%llx %*s %ms [ %*[^]] ]", &ppc, &name);
 		uppc = (__u64)ppc;
 		if ((uipc >= ulpc) &&
 		    (uipc < uppc)) {


### PR DESCRIPTION
Hi Pavel Odintsov 😄 

I found a build error on my system like below:
```
$ cd drop_watch/src

$ make
gcc -I/usr/include/libnl3/  -c -g -D_GNU_SOURCE -Wall -Werror lookup_kas.c
lookup_kas.c: In function ‘lookup_kas_proc’:
lookup_kas.c:104:25: error: format ‘%a’ expects argument of type ‘float *’, but argument 4 has type ‘char **’ [-Werror=format=]
   fscanf(pf, "%llx %*s %as [ %*[^]] ]", &ppc, &name);

```
And then I checked the below link that explain why the warning happen
  https://gcc.gnu.org/gcc-5/porting_to.html
```
Different meaning of the %a *scanf conversion specification

In C89, the GNU C library supports dynamic allocation via the %as, %aS, and %a[...] conversion specifications; see this for more info. In C99, the a conversion specifier is a synonym for f (float), so the compiler expects an argument of type float *. This is a change in semantics, and in combination with the -Wformat warning option the compiler may emit additional warnings:


  #include <stdio.h>

  int
  main (void)
  {
    char *s;
    scanf ("%as", &s);
  }
q.c:7:10: warning: format '%a' expects argument of type 'float *', but argument 2 has type 'char **' [-Wformat=]
  scanf ("%as", &s);
         ^
To use the dynamic allocation conversion specifier in C99 and C11, specify m as a length modifier as per POSIX.1-2008. That is, use %ms or %m[...].
```

So change the format `%as` -> `%ms`

Thanks,
Taeung